### PR TITLE
Update codeql and releases.yml

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -5,6 +5,8 @@
       # Replace llvmPackages with llvmPackages_X, where X is the latest LLVM version (at the time of writing, 16)
       llvmPackages.bintools
       rustup
+      bunyan-rs
+      go
     ];
     RUSTC_VERSION = pkgs.lib.readFile ./rust-toolchain;
     # https://github.com/rust-lang/rust-bindgen#environment-variables

--- a/skootrs-lib/templates/codeql.yml
+++ b/skootrs-lib/templates/codeql.yml
@@ -65,6 +65,10 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
+    - name: Set up Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version: "1.21"
 
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/skootrs-lib/templates/go.releases.yml
+++ b/skootrs-lib/templates/go.releases.yml
@@ -27,6 +27,7 @@ on:
 
 permissions:
   actions: read # for detecting the Github Actions environment.
+  contents: read
 
 jobs:
   goreleaser:
@@ -138,6 +139,11 @@ jobs:
           IMAGE_URI_DIGEST: ${{ needs.goreleaser.outputs.image }}@${{ needs.goreleaser.outputs.digest }}
 
   provenance-bins:
+    permissions:
+      id-token: write
+      actions: read
+      contents: write
+      packages: write
     name: generate provenance for binaries
     needs: [goreleaser]
     if: startsWith(github.ref, 'refs/tags/')
@@ -148,6 +154,11 @@ jobs:
 
   provenance-container:
     name: generate provenance for container
+    permissions:
+      id-token: write
+      actions: read
+      contents: write
+      packages: write
     needs: [goreleaser]
     if: startsWith(github.ref, 'refs/tags/')
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.9.0 # must use semver here


### PR DESCRIPTION
Codeql is updated to include go 1.21.X so it works right. This is due to changes in the go.mod parsing in go > 1.21. By default Codeql has Go 1.20 but I was informed that is just by coincidence and the version of Go included should not be relied on.

Releases is updated with correct token permissions where needed. Releases still doesn't work 100% yet and is being worked on.