### PR TITLE
Fix Go release facet

### DIFF
--- a/skootrs-lib/templates/Dockerfile.goreleaser
+++ b/skootrs-lib/templates/Dockerfile.goreleaser
@@ -1,0 +1,8 @@
+FROM --platform=$BUILDPLATFORM alpine:latest@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b as certs
+RUN apk --update add ca-certificates
+
+FROM --platform=$BUILDPLATFORM alpine:latest@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+RUN apk --update --no-cache add wget && rm -rf /var/cache/apk/*
+
+workdir /{{ project_name }}

--- a/skootrs-lib/templates/go.releases.yml
+++ b/skootrs-lib/templates/go.releases.yml
@@ -1,4 +1,5 @@
 {% raw %}
+
 #
 # Copyright 2022 The GUAC Authors.
 #
@@ -107,6 +108,9 @@ jobs:
 
   sbom-container:
     # generate sbom for container as goreleaser can't - https://goreleaser.com/customization/sbom/#limitations
+    permissions:
+      id-token: write
+      packages: write
     name: generate sbom for container
     runs-on: ubuntu-latest
     needs: [goreleaser]
@@ -132,8 +136,7 @@ jobs:
         run: |
           #!/usr/bin/env bash
           set -euo pipefail
-          cosign attach sbom --sbom spdx.sbom.json ${IMAGE_URI_DIGEST}
-          cosign sign -a git_sha=$GITHUB_SHA --attachment sbom ${IMAGE_URI_DIGEST} --yes
+          cosign attest --predicate spdx.sbom.json ${IMAGE_URI_DIGEST} --yes
         shell: bash
         env:
           IMAGE_URI_DIGEST: ${{ needs.goreleaser.outputs.image }}@${{ needs.goreleaser.outputs.digest }}

--- a/skootrs-lib/templates/goreleaser.yml
+++ b/skootrs-lib/templates/goreleaser.yml
@@ -1,0 +1,137 @@
+---
+project_name: {{ project_name }}
+
+
+env:
+  - CGO_ENABLED=0
+  - PKG={{ module_name }}
+{% raw %}
+
+dockers:
+  # see details at https://goreleaser.com/customization/docker/
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Tag }}-amd64"
+    dockerfile: Dockerfile.goreleaser
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--builder={{ .Env.DOCKER_CONTEXT }}"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Tag }}-arm64"
+    dockerfile: Dockerfile.goreleaser
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--builder={{ .Env.DOCKER_CONTEXT }}"
+
+docker_manifests:
+  - name_template: "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Tag }}"
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Tag }}-amd64"
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Tag }}-arm64"
+
+docker_signs:
+  - cmd: cosign
+    artifacts: all
+    output: true
+    args:
+      - "sign"
+      - "--a"
+      - "git_sha={{.FullCommit}}"
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}@${digest}"
+      - "--yes"
+
+before:
+  hooks:
+    - go mod tidy
+    - go generate ./...
+
+builds:
+  - main: ./
+    id: main
+    binary: main-{{ .Os }}-{{ .Arch }}
+    ldflags:
+      # See https://goreleaser.com/customization/templates/#common-fields for field definitions
+      - -X {{.Env.PKG}}.Commit={{.FullCommit}}
+      - -X {{.Env.PKG}}.Date={{.Date}}
+      - -X {{.Env.PKG}}.Version={{.Summary}}
+    goos: [ 'darwin', 'linux', 'windows' ]
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+
+universal_binaries:
+  - replace: true
+    name_template: main
+    id: main
+    ids:
+      - main
+
+sboms:
+  - id: bins
+    artifacts: binary
+    documents:
+      - "${artifact}.spdx.sbom.json"
+
+signs:
+  - id: cosign-keyless
+    artifacts: checksum
+    signature: "${artifact}-keyless.sig"
+    certificate: "${artifact}-keyless.pem"
+    cmd: cosign
+    args:
+      - "sign-blob"
+      - "--yes"
+      - "--output-signature"
+      - "${artifact}-keyless.sig"
+      - "--output-certificate"
+      - "${artifact}-keyless.pem"
+      - "${artifact}"
+    output: true
+
+archives:
+  - format: binary
+    name_template: "{{ .Binary }}"
+    allow_different_binary_count: true
+
+checksum:
+  name_template: "{{ .ProjectName }}_checksums.txt"
+
+snapshot:
+  name_template: SNAPSHOT-{{ .ShortCommit }}
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  prerelease: auto
+  draft: false
+  replace_existing_draft: true
+# The lines beneath this are called `modelines`. See `:help modeline`
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+{% endraw %}


### PR DESCRIPTION
This updates the SLSA SourceBundleFacet for Go to include docker correctly and templatize a few things in the right places.