### PR TITLE
Refactor CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,6 +932,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
+name = "clap_mangen"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1dd95b5ebb5c1c54581dd6346f3ed6a79a3eef95dd372fc2ac13d535535300e"
+dependencies = [
+ "clap",
+ "roff",
+]
+
+[[package]]
+name = "clio"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7fc6734af48458f72f5a3fa7b840903606427d98a710256e808f76a965047d9"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "is-terminal",
+ "libc",
+ "tempfile",
+ "walkdir",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3377,6 +3402,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
+
+[[package]]
 name = "rsa"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3702,18 +3733,18 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3923,12 +3954,15 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "clap",
+ "clap_mangen",
+ "clio",
  "inquire",
  "octocrab 0.32.0",
  "opentelemetry",
  "opentelemetry-jaeger",
  "opentelemetry_sdk",
  "reqwest",
+ "serde",
  "serde_json",
  "serde_yaml",
  "skootrs-lib",
@@ -5217,6 +5251,21 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -5265,6 +5314,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -5274,6 +5329,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5289,6 +5350,12 @@ checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
@@ -5298,6 +5365,12 @@ name = "windows_i686_gnu"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5313,6 +5386,12 @@ checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -5325,6 +5404,12 @@ checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -5334,6 +5419,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/README.md
+++ b/README.md
@@ -16,28 +16,71 @@ Skootrs is currently pre-release so you will need to use cargo to compile and ru
 
 ```shell
 $ cargo run
+Skootrs is a CLI tool for creating and managing secure-by-default projects. The commands are  using noun-verb syntax. So the commands are structured like: `skootrs <noun> <verb>`. For example, `skootrs project create`
+
 Usage: skootrs <COMMAND>
 
 Commands:
-  create     
-  daemon     
-  dump       
-  get-facet
-  get  
-  help       Print this message or the help of the given subcommand(s)
+  project  Project commands
+  facet    Facet commands
+  output   Output commands
+  daemon   Daemon commands
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help (see more with '--help')
 ```
 
-- Create - The main command for creating a Skootrs secure-by-default repo.
-- Daemon - The command for running Skootrs as a REST API.
-- Dump - The command for dumping the output of Skootrs' state database to stdout. Useful for debugging.
-- Get-Facet - The command for dumping the file or API output for a facet for a given project.
-- Get - This is a new command that will be the verb for getting items that Skootrs knows abou
-  - Output - This is a verb for the Get command that will fetch outputs from Skootrs project. Currently this only supports getting SBOMs
+Project:
+```shell
+Usage: skootrs project <COMMAND>
+
+Commands:
+  create  Create a new project
+  get     Get the metadata for a particular project
+  list    List all the projects known to the local Skootrs
+  help    Print this message or the help of the given subcommand(s)
+```
+
+Facet:
+```shell
+Facet commands
+
+Usage: skootrs facet <COMMAND>
+
+Commands:
+  get   Get the data for a facet of a particular project
+  list  List all the facets that belong to a particular project
+  help  Print this message or the help of the given subcommand(s)
+```
+
+Output:
+```shell
+Output commands
+
+Usage: skootrs output <COMMAND>
+
+Commands:
+  get   Get the data for a release output of a particular project
+  list  List all the release outputs that belong to a particular project
+  help  Print this message or the help of the given subcommand(s)
+```
+
+Daemon:
+```shell
+Daemon commands
+
+Usage: skootrs daemon <COMMAND>
+
+Commands:
+  start  Start the REST server
+  help   Print this message or the help of the given subcommand(s)
+```
 
 To get pretty printing of the logs which are in [bunyan](https://github.com/trentm/node-bunyan) format I recommend piping the skootrs into the bunyan cli. I recommend using [bunyan-rs](https://github.com/LukeMathWalker/bunyan). For example:
 
 ```shell
-$ cargo run create | bunyan                                                              ~/Projects/skootrs
+$ cargo run project create | bunyan                                                              ~/Projects/skootrs
     Finished dev [unoptimized + debuginfo] target(s) in 0.19s
      Running `target/debug/skootrs-bin create`
 > The name of the repository skoot-test-bunyan

--- a/skootrs-bin/Cargo.toml
+++ b/skootrs-bin/Cargo.toml
@@ -25,3 +25,8 @@ opentelemetry_sdk = "0.21.2"
 serde_yaml = "0.9.32"
 reqwest = "0.11.24"
 base64 = "0.21.7"
+clio = { version = "0.3.5", features = ["clap", "clap-parse"] }
+serde = "1.0.197"
+
+[build-dependencies]
+clap_mangen = "0.2.20"

--- a/skootrs-model/src/skootrs/mod.rs
+++ b/skootrs-model/src/skootrs/mod.rs
@@ -251,3 +251,18 @@ impl GoParams {
         format!("{}/{}", self.host, self.name)
     }
 }
+
+/// A set of configuration options for Skootrs.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct SkootrsConfig {
+    pub local_project_path: String,
+}
+
+impl Default for SkootrsConfig {
+    fn default() -> Self {
+        Self {
+            local_project_path: "/tmp".into()
+        }
+    }
+}


### PR DESCRIPTION
This standardizes the CLI on noun-verb commands. This also begins to structure the command line helpers to be more generic and take in things like config and only do the interactive prompt if params from a file, stdin, url, or pipe in yaml or json format is not passed.

Right now only project create functionality has been completely refactored in this way, but the other commands shouldn't be much longer