### PR TITLE
Add crates token to github action

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -78,13 +78,10 @@ jobs:
         run: cargo install cargo-release
       - name: Public to crates.io
         if: startsWith(github.ref, 'refs/tags/')
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          cargo release -p skootrs-model --execute
-          cargo release -p skootrs-lib --execute
-          cargo release -p skootrs-statestore --execute
-          cargo release -p skootrs-rest --execute
-          cargo release -p skootrs-bin --execute
-           
+          cargo release --execute --no-confirm
   sbom:
     permissions:
       contents: write


### PR DESCRIPTION
Also looks like when publishing it should automatically take care of converting paths to versions.